### PR TITLE
fix: remove `ascii` encoding from parsing `next` param and use default 'utf-8' instead

### DIFF
--- a/src/dynamo-querier.ts
+++ b/src/dynamo-querier.ts
@@ -154,7 +154,7 @@ export class DynamoQuerier<
       ...(options.next
         ? {
             ExclusiveStartKey: JSON.parse(
-              Buffer.from(options.next, 'base64').toString('ascii'),
+              Buffer.from(options.next, 'base64').toString(),
             ),
           }
         : {}),
@@ -333,7 +333,7 @@ class QueryAllExecutor<D extends DynamoInfo, PROJECTION>
     ...(this.options.next
       ? {
           ExclusiveStartKey: JSON.parse(
-            Buffer.from(this.options.next, 'base64').toString('ascii'),
+            Buffer.from(this.options.next, 'base64').toString(),
           ),
         }
       : {}),

--- a/src/dynamo-scanner.ts
+++ b/src/dynamo-scanner.ts
@@ -68,7 +68,7 @@ export class DynamoScanner<T extends DynamoInfo> {
     const member = result.member;
     while (result.next) {
       executor.input.ExclusiveStartKey = JSON.parse(
-        Buffer.from(result.next, 'base64').toString('ascii'),
+        Buffer.from(result.next, 'base64').toString(),
       );
       if (this.config.logStatements) {
         console.log(`ScanInput: ${JSON.stringify(executor.input, null, 2)}`);
@@ -111,7 +111,7 @@ export class DynamoScanner<T extends DynamoInfo> {
       ...(options.next
         ? {
             ExclusiveStartKey: JSON.parse(
-              Buffer.from(options.next, 'base64').toString('ascii'),
+              Buffer.from(options.next, 'base64').toString(),
             ),
           }
         : {}),


### PR DESCRIPTION
https://github.com/hexlabsio/dynamo-ts/issues/26