### PR TITLE
feature: introduce support for empty filter queries

### DIFF
--- a/src/comparison.ts
+++ b/src/comparison.ts
@@ -135,6 +135,7 @@ class ComparisonBuilderType<T> {
   }
 
   empty(): Wrapper {
+    this.wrapper.expression = "";
     return this.wrapper;
   }
 

--- a/src/comparison.ts
+++ b/src/comparison.ts
@@ -44,6 +44,7 @@ export type ComparisonBuilderFrom<TableType> = {
   or(
     ...comparisons: CompareWrapperOperator<Required<TableType>>[]
   ): CompareWrapperOperator<Required<TableType>>;
+  empty(): CompareWrapperOperator<Required<TableType>>;
 } & Digger<TableType>;
 
 export type ComparisonBuilder<T> = { [K in keyof T]: Operation<T, T[K]> } & {
@@ -130,6 +131,10 @@ class ComparisonBuilderType<T> {
 
   not(comparison: Wrapper): Wrapper {
     this.wrapper.expression = `NOT (${comparison.expression})`;
+    return this.wrapper;
+  }
+
+  empty(): Wrapper {
     return this.wrapper;
   }
 

--- a/src/dynamo-querier.ts
+++ b/src/dynamo-querier.ts
@@ -133,7 +133,7 @@ export class DynamoQuerier<TableConfig extends TableDefinition> {
         ? { IndexName: this.clientConfig.indexName }
         : {}),
       ...{ KeyConditionExpression: keyExpression },
-      ...(options.filter ? { FilterExpression: filterPart } : {}),
+      ...(options.filter && filterPart ? { FilterExpression: filterPart } : {}),
       ...(options.projection ? { ProjectionExpression: projection } : {}),
       ReturnConsumedCapacity: options.returnConsumedCapacity,
       ScanIndexForward: options.scanIndexForward,

--- a/test/dynamo-querier.spec.ts
+++ b/test/dynamo-querier.spec.ts
@@ -375,6 +375,22 @@ describe('Dynamo Querier', () => {
         scannedCount: 4,
       });
     });
+
+    it('should filter nothing', async () => {
+      const result = await testTable2.query(
+          { identifier },
+          {
+            filter: compare => compare().empty()
+          },
+      );
+      expect(result).toEqual({
+        member: [preInserts2[0], preInserts2[1], preInserts2[2], preInserts2[3]],
+        count: 4,
+        scannedCount: 4,
+        consumedCapacity: undefined,
+        next: undefined,
+      });
+    })
   });
 
   describe('Scan Index Forward', () => {


### PR DESCRIPTION
feature: introduce support for empty filter queries

- Added an `empty()` method in `comparison.ts` to allow queries with no filter expressions.
- Updated `dynamo-querier.ts` to handle scenarios where filter is empty.
- Added a test case to validate behavior when no filter is applied.

Enables easier filter construction